### PR TITLE
bump helm chart version to 0.4.4

### DIFF
--- a/vagrant/.env
+++ b/vagrant/.env
@@ -5,7 +5,7 @@ MACHINE1_IP=192.168.56.43
 MACHINE1_MAC=08:00:27:9e:f5:3a
 
 # https://github.com/tinkerbell/charts/pkgs/container/charts%2Fstack
-HELM_CHART_VERSION=0.4.3
+HELM_CHART_VERSION=0.4.4
 KUBECTL_VERSION=1.27.12
 # K3D version v5.6.3 doesn't work with host networking. https://github.com/k3d-io/k3d/issues/964
 K3D_VERSION=v5.6.0


### PR DESCRIPTION
## Description

bump helm chart version to 0.4.4

## Why is this needed

there were updates to hook os repository in the last release which updates the hook os download configmap 

Fixes: #

## How Has This Been Tested?
leveraged my branch to `vagrant up` and `vagrant up machine1` to see the implementation through to success.
helm install command from `setup.sh`
![image](https://github.com/tinkerbell/playground/assets/19310351/fbd608e3-5471-42e1-9c92-b131397afb39)
successful download of hook
![image](https://github.com/tinkerbell/playground/assets/19310351/1655ff74-1158-4e7d-96da-d5ec90e9ccec)
successful workflow execution 
![image](https://github.com/tinkerbell/playground/assets/19310351/b2880863-4cfa-4dca-8b11-6ef1d7518b28)


## How are existing users impacted? What migration steps/scripts do we need?
n/a


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
