### PR TITLE
bump helm chart version to 0.4.4

### DIFF
--- a/vagrant/.env
+++ b/vagrant/.env
@@ -5,7 +5,7 @@ MACHINE1_IP=192.168.56.43
 MACHINE1_MAC=08:00:27:9e:f5:3a
 
 # https://github.com/tinkerbell/charts/pkgs/container/charts%2Fstack
-HELM_CHART_VERSION=0.4.3
+HELM_CHART_VERSION=0.4.4
 KUBECTL_VERSION=1.27.12
 # K3D version v5.6.3 doesn't work with host networking. https://github.com/k3d-io/k3d/issues/964
 K3D_VERSION=v5.6.0


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #
bumps helm chart to 0.4.4 to fix hook os download
## How Has This Been Tested?
provisioned a new stack from my branch and ensured the hook os download completed and workflow runs successfully


## How are existing users impacted? What migration steps/scripts do we need?
n/a


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
