### PR TITLE
Add sleep to reduce logging output

### DIFF
--- a/stack/vagrant/setup.sh
+++ b/stack/vagrant/setup.sh
@@ -71,7 +71,7 @@ helm_install_tink_stack() {
 	trusted_proxies=""
 	until [ "$trusted_proxies" != "" ]; do
 		trusted_proxies=$(kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}' | tr ' ' ',')
-  		sleep 5
+		sleep 5
 	done
 	helm install tink-stack oci://ghcr.io/tinkerbell/charts/stack \
 		--version "$version" \

--- a/stack/vagrant/setup.sh
+++ b/stack/vagrant/setup.sh
@@ -71,6 +71,7 @@ helm_install_tink_stack() {
 	trusted_proxies=""
 	until [ "$trusted_proxies" != "" ]; do
 		trusted_proxies=$(kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}' | tr ' ' ',')
+  		sleep 5
 	done
 	helm install tink-stack oci://ghcr.io/tinkerbell/charts/stack \
 		--version "$version" \


### PR DESCRIPTION
## Description

The command `kubectl get nodes -o 'jsonpath={.items[*].spec.podCIDR}'` is executed in a loop. When I run `vagrant up` the my screen is filled with:
```
    stack: ++ kubectl get nodes -o 'jsonpath={.items[*].spec.podCIDR}'
    stack: ++ tr ' ' ,
    stack: + trusted_proxies=
    stack: + '[' '' '!=' '' ']'
    stack: ++ kubectl get nodes -o 'jsonpath={.items[*].spec.podCIDR}'
    stack: ++ tr ' ' ,
    stack: + trusted_proxies=
    stack: + '[' '' '!=' '' ']'
    stack: ++ kubectl get nodes -o 'jsonpath={.items[*].spec.podCIDR}'
    stack: ++ tr ' ' ,
    stack: + trusted_proxies=
    stack: + '[' '' '!=' '' ']'
```


## Why is this needed

To reduce the verbosity.

## How Has This Been Tested?
Tested on my on machine. It worked before the change. It worked after the change with less output. 
```
    stack: + local loadbalancer_ip=192.168.56.5
    stack: + trusted_proxies=
    stack: + '[' '' '!=' '' ']'
    stack: ++ kubectl get nodes -o 'jsonpath={.items[*].spec.podCIDR}'
    stack: ++ tr ' ' ,
    stack: + trusted_proxies=
    stack: + sleep 5
    stack: + '[' '' '!=' '' ']'
    stack: ++ kubectl get nodes -o 'jsonpath={.items[*].spec.podCIDR}'
    stack: ++ tr ' ' ,
    stack: + trusted_proxies=
    stack: + sleep 5
    stack: + '[' '' '!=' '' ']'
    stack: ++ tr ' ' ,
    stack: ++ kubectl get nodes -o 'jsonpath={.items[*].spec.podCIDR}'
    stack: + trusted_proxies=10.42.0.0/24
    stack: + sleep 5
    stack: + '[' 10.42.0.0/24 '!=' '' ']'
    stack: + helm install tink-stack oci://ghcr.io/tinkerbell/charts/stack --version 0.4.5 --create-namespace --namespace tink-system --wait --set 'smee.trustedProxies={10.42.0.0/24}' --set 'hegel.trustedProxies={10.42.0.0/24}' --set stack.kubev
```


## How are existing users impacted? What migration steps/scripts do we need?
N/A


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
