### PR TITLE
Use Ubuntu 24.04 (Noble)

### DIFF
--- a/stack/vagrant/template.yaml
+++ b/stack/vagrant/template.yaml
@@ -20,7 +20,7 @@ spec:
             timeout: 600
             environment:
               DEST_DISK: {{ index .Hardware.Disks 0 }}
-              IMG_URL: "http://$TINKERBELL_HOST_IP:8080/jammy-server-cloudimg-amd64.raw.gz"
+              IMG_URL: "http://$TINKERBELL_HOST_IP:8080/noble-server-cloudimg-amd64.raw.gz"
               COMPRESSED: true
           - name: "grow-partition"
             image: quay.io/tinkerbell/actions/cexec:latest
@@ -92,9 +92,12 @@ spec:
             timeout: 90
             pid: host
             environment:
-              BLOCK_DEVICE: {{ formatPartition ( index .Hardware.Disks 0 ) 1 }}
+              BLOCK_DEVICE: {{ formatPartition ( index .Hardware.Disks 0 ) 16 }}
               FS_TYPE: ext4
               IMAGE: quay.io/tinkerbell/actions/kexec:latest
               WAIT_SECONDS: 10
+              KERNEL_PATH: vmlinuz
+              INITRD_PATH: initrd.img
+              CMD_LINE: "root={{ formatPartition ( index .Hardware.Disks 0 ) 1 }} ro"
             volumes:
               - /var/run/docker.sock:/var/run/docker.sock

--- a/stack/vagrant/ubuntu-download.yaml
+++ b/stack/vagrant/ubuntu-download.yaml
@@ -26,17 +26,17 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: download-ubuntu-jammy
+  name: download-ubuntu-noble
 spec:
   template:
     spec:
       containers:
-        - name: download-ubuntu-jammy
+        - name: download-ubuntu-noble
           image: bash:5.2.2
           command: ["/script/entrypoint.sh"]
           args:
             [
-              "https://cloud-images.ubuntu.com/daily/server/jammy/current/jammy-server-cloudimg-amd64.img",
+              "https://cloud-images.ubuntu.com/daily/server/noble/current/noble-server-cloudimg-amd64.img",
               "/output",
             ]
           volumeMounts:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Currently when running the instructions on https://github.com/tinkerbell/playground/blob/main/stack/docs/quickstarts/VAGRANTLVIRT.md, the result is an ssh shell on a machine where Ubuntu 22.04 is installed. This will change it to Ubuntu 24.04.

## Why is this needed
Ubuntu 24.04 is the latest LTS release.
<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
Ran it locally on my laptop.

## How are existing users impacted? What migration steps/scripts do we need?
Users will see the latest Ubuntu LTS Ubuntu 24.04 (Noble) instead of the previous Ubuntu LTS 22.04 (Jammy)

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
