### PR TITLE
Update to Tink chart 0.5.0:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ error.log
 .state
 capt/output/
 .vscode/
+sushy.cert
+sushy.key
+htpasswd

--- a/capt/config.yaml
+++ b/capt/config.yaml
@@ -7,11 +7,17 @@ counts:
   workers: 1
   spares: 1
 versions:
-  capt: 0.5.3
+  capt: v0.5.3
   chart: 0.5.0
   kube: v1.29.4
   os: 20.04
   kubevip: 0.8.2
+capt:
+  infrastructureYaml: "https://github.com/tinkerbell/cluster-api-provider-tinkerbell/releases"
+  #infrastructureYaml: "/home/tink/repos/tinkerbell/cluster-api-provider-tinkerbell/out/release/infrastructure-tinkerbell"
+chart:
+  location: "oci://ghcr.io/tinkerbell/charts/stack"
+  #location: "/home/tink/repos/tinkerbell/charts/tinkerbell/stack"
 os:
   registry: ghcr.io/tinkerbell/cluster-api-provider-tinkerbell
   distro: ubuntu
@@ -24,6 +30,6 @@ vm:
   diskPath: "/tmp"
 virtualBMC:
   containerName: "virtualbmc"
-  image: ghcr.io/jacobweinstock/virtualbmc
+  image: ghcr.io/jacobweinstock/virtualbmc:latest
   user: "root"
   pass: "calvin"

--- a/capt/config.yaml
+++ b/capt/config.yaml
@@ -8,7 +8,7 @@ counts:
   spares: 1
 versions:
   capt: 0.5.3
-  chart: 0.4.5
+  chart: 0.5.0
   kube: v1.29.4
   os: 20.04
   kubevip: 0.8.2

--- a/capt/config.yaml
+++ b/capt/config.yaml
@@ -13,8 +13,8 @@ versions:
   os: 20.04
   kubevip: 0.8.2
 capt:
-  infrastructureYaml: "https://github.com/tinkerbell/cluster-api-provider-tinkerbell/releases"
-  #infrastructureYaml: "/home/tink/repos/tinkerbell/cluster-api-provider-tinkerbell/out/release/infrastructure-tinkerbell"
+  providerRepository: "https://github.com/tinkerbell/cluster-api-provider-tinkerbell/releases"
+  #providerRepository: "/home/tink/repos/tinkerbell/cluster-api-provider-tinkerbell/out/release/infrastructure-tinkerbell"
 chart:
   location: "oci://ghcr.io/tinkerbell/charts/stack"
   #location: "/home/tink/repos/tinkerbell/charts/tinkerbell/stack"

--- a/capt/scripts/generate_state.sh
+++ b/capt/scripts/generate_state.sh
@@ -13,7 +13,7 @@ counts:
   spares: 1
 versions:
   capt: 0.5.3
-  chart: 0.4.4
+  chart: 0.5.0
   kube: v1.28.8
   os: 22.04
 os:

--- a/capt/scripts/sushy-tools.conf
+++ b/capt/scripts/sushy-tools.conf
@@ -1,0 +1,26 @@
+SUSHY_EMULATOR_LISTEN_IP = u'0.0.0.0'
+SUSHY_EMULATOR_LISTEN_PORT = 443
+SUSHY_EMULATOR_OS_CLOUD = None
+SUSHY_EMULATOR_LIBVIRT_URI = u'qemu:///system'
+SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = False
+SUSHY_EMULATOR_FEATURE_SET = u'full'
+SUSHY_EMULATOR_AUTH_FILE = u'/etc/sushy/htpasswd'
+SUSHY_EMULATOR_SSL_CERT = u'/etc/sushy/sushy.cert'
+SUSHY_EMULATOR_SSL_KEY = u'/etc/sushy/sushy.key'
+SUSHY_EMULATOR_BOOT_LOADER_MAP = {
+    u'UEFI': {
+        u'x86_64': u'/usr/share/OVMF/OVMF_CODE.fd'
+    },
+    u'Legacy': {
+        u'x86_64': None
+    }
+}
+SUSHY_EMULATOR_VMEDIA_DEVICES = {
+    u'Cd': {
+        u'Name': 'Virtual CD',
+        u'MediaTypes': [
+            u'CD',
+            u'DVD'
+        ]
+    }
+}

--- a/capt/scripts/virtualbmc.sh
+++ b/capt/scripts/virtualbmc.sh
@@ -16,7 +16,6 @@ function main() {
 		docker exec "$container_name" vbmc add --username "$username" --password "$password" --port "$port" "$name"
 		docker exec "$container_name" vbmc start "$name"
 	done < <(yq e '.vm.details.[] | [key, .bmc.port] | @csv' "$STATE_FILE")
-
 }
 
 main "$@"

--- a/capt/tasks/Taskfile-capi.yaml
+++ b/capt/tasks/Taskfile-capi.yaml
@@ -18,11 +18,13 @@ tasks:
     env:
       CAPT_VERSION:
         sh: yq eval '.versions.capt' {{.STATE_FILE_FQ_PATH}}
+      LOCATION:
+        sh: yq eval '.capt.infrastructureYaml' {{.STATE_FILE_FQ_PATH}}
     vars:
       OUTPUT_DIR:
         sh: echo $(yq eval '.outputDir' config.yaml)
     cmds:
-      - envsubst '$CAPT_VERSION' < templates/clusterctl.tmpl > {{.OUTPUT_DIR}}/clusterctl.yaml
+      - envsubst '$CAPT_VERSION,$LOCATION' < templates/clusterctl.tmpl > {{.OUTPUT_DIR}}/clusterctl.yaml
     status:
       - grep -q "$CAPT_VERSION" {{.OUTPUT_DIR}}/clusterctl.yaml
 

--- a/capt/tasks/Taskfile-capi.yaml
+++ b/capt/tasks/Taskfile-capi.yaml
@@ -19,7 +19,7 @@ tasks:
       CAPT_VERSION:
         sh: yq eval '.versions.capt' {{.STATE_FILE_FQ_PATH}}
       LOCATION:
-        sh: yq eval '.capt.infrastructureYaml' {{.STATE_FILE_FQ_PATH}}
+        sh: yq eval '.capt.providerRepository' {{.STATE_FILE_FQ_PATH}}
     vars:
       OUTPUT_DIR:
         sh: echo $(yq eval '.outputDir' config.yaml)

--- a/capt/tasks/Taskfile-create.yaml
+++ b/capt/tasks/Taskfile-create.yaml
@@ -111,7 +111,7 @@ tasks:
         sh: yq eval '.namespace' {{.STATE_FILE_FQ_PATH}}
       CHART_NAME: tink-stack
     cmds:
-      - KUBECONFIG="{{.KUBECONFIG}}" helm install {{.CHART_NAME}} oci://ghcr.io/tinkerbell/charts/stack --version "{{.STACK_CHART_VERSION}}" --create-namespace --namespace {{.NAMESPACE}} --wait --set "smee.trustedProxies={{.TRUSTED_PROXIES}}" --set "hegel.trustedProxies={{.TRUSTED_PROXIES}}" --set "stack.loadBalancerIP={{.LB_IP}}" --set "smee.publicIP={{.LB_IP}}"
+      - KUBECONFIG="{{.KUBECONFIG}}" helm install {{.CHART_NAME}} oci://ghcr.io/tinkerbell/charts/stack --version "{{.STACK_CHART_VERSION}}" --create-namespace --namespace {{.NAMESPACE}} --wait --set "global.trustedProxies={"{{.TRUSTED_PROXIES}}"}" --set "global.publicIP={{.LB_IP}}"
     status:
       - KUBECONFIG="{{.KUBECONFIG}}" helm list -n {{.NAMESPACE}} | grep -q {{.CHART_NAME}}
 

--- a/capt/tasks/Taskfile-create.yaml
+++ b/capt/tasks/Taskfile-create.yaml
@@ -13,6 +13,7 @@ tasks:
       - task: kind-cluster
       - task: update-state
       - task: deploy-tinkerbell-helm-chart
+      - task: vbmc:prepare
       - task: vbmc:start-server
       - task: vbmc:update-state
       - task: hardware-cr
@@ -109,9 +110,11 @@ tasks:
         sh: yq eval '.versions.chart' {{.STATE_FILE_FQ_PATH}}
       NAMESPACE:
         sh: yq eval '.namespace' {{.STATE_FILE_FQ_PATH}}
+      LOCATION:
+        sh: yq eval '.chart.location' {{.STATE_FILE_FQ_PATH}}
       CHART_NAME: tink-stack
     cmds:
-      - KUBECONFIG="{{.KUBECONFIG}}" helm install {{.CHART_NAME}} oci://ghcr.io/tinkerbell/charts/stack --version "{{.STACK_CHART_VERSION}}" --create-namespace --namespace {{.NAMESPACE}} --wait --set "global.trustedProxies={"{{.TRUSTED_PROXIES}}"}" --set "global.publicIP={{.LB_IP}}"
+      - KUBECONFIG="{{.KUBECONFIG}}" helm install {{.CHART_NAME}} {{.LOCATION}} --version "{{.STACK_CHART_VERSION}}" --create-namespace --namespace {{.NAMESPACE}} --wait --set "global.trustedProxies={"{{.TRUSTED_PROXIES}}"}" --set "global.publicIP={{.LB_IP}}" --set "rufio.image=quay.io/tinkerbell/rufio:latest"
     status:
       - KUBECONFIG="{{.KUBECONFIG}}" helm list -n {{.NAMESPACE}} | grep -q {{.CHART_NAME}}
 

--- a/capt/tasks/Taskfile-delete.yaml
+++ b/capt/tasks/Taskfile-delete.yaml
@@ -7,6 +7,7 @@ tasks:
     cmds:
       - task: kind-cluster
       - task: vbmc-container
+      - task: vbmc-generated-files
       - task: vms
       - task: output-dir
 
@@ -47,6 +48,16 @@ tasks:
       - docker rm -f {{.VBMC_CONTAINER_NAME}}
     status:
       - got=$(docker ps -a | grep -c {{.VBMC_CONTAINER_NAME}} || :); [[ "$got" == "0" ]]
+
+  vbmc-generated-files:
+    summary: |
+      Delete the Virtual BMC generated files.
+    cmds:
+      - rm -f {{.CURR_DIR}}/scripts/htpasswd {{.CURR_DIR}}/scripts/sushy.key {{.CURR_DIR}}/scripts/sushy.cert
+    status:
+      - test ! -f {{.CURR_DIR}}/scripts/htpasswd
+      - test ! -f {{.CURR_DIR}}/scripts/sushy.key
+      - test ! -f {{.CURR_DIR}}/scripts/sushy.cert
 
   output-dir:
     summary: |

--- a/capt/tasks/Taskfile-vbmc.yaml
+++ b/capt/tasks/Taskfile-vbmc.yaml
@@ -1,8 +1,28 @@
 version: "3"
 
 tasks:
+  prepare:
+    run: once
+    summary: |
+      Prepare the virtualbmc server.
+    vars:
+      VBMC_CONTAINER_IMAGE:
+        sh: yq eval '.virtualBMC.image' {{.STATE_FILE_FQ_PATH}}
+      USERNAME:
+        sh: yq eval '.virtualBMC.user' {{.STATE_FILE_FQ_PATH}}
+      PASSWORD:
+        sh: yq eval '.virtualBMC.pass' {{.STATE_FILE_FQ_PATH}}
+    cmds:
+      - docker run -it --rm --entrypoint htpasswd {{.VBMC_CONTAINER_IMAGE}} -nbB "{{.USERNAME}}" "{{.PASSWORD}}" > {{.CURR_DIR}}/scripts/htpasswd
+      - docker run -it --rm --entrypoint openssl -v {{.CURR_DIR}}/scripts:/scripts {{.VBMC_CONTAINER_IMAGE}} req -x509 -newkey rsa:2048 -keyout /scripts/sushy.key -out /scripts/sushy.cert -days 365 -nodes -subj "/C=US/ST=CA/L=Los Angeles/O=Engineering/OU=Engineering/CN=tinkerbell.org"
+    status:
+      - test -f {{.CURR_DIR}}/scripts/htpasswd
+      - test -f {{.CURR_DIR}}/scripts/sushy.key
+      - test -f {{.CURR_DIR}}/scripts/sushy.cert
+
   start-server:
     run: once
+    deps: [prepare]
     summary: |
       Start the virtualbmc server. Requires the "kind" docker network to exist.
     vars:
@@ -11,7 +31,7 @@ tasks:
       VBMC_CONTAINER_IMAGE:
         sh: yq eval '.virtualBMC.image' {{.STATE_FILE_FQ_PATH}}
     cmds:
-      - docker run -d --privileged --rm --network kind -v /var/run/libvirt/libvirt-sock-ro:/var/run/libvirt/libvirt-sock-ro -v /var/run/libvirt/libvirt-sock:/var/run/libvirt/libvirt-sock --name {{.VBMC_CONTAINER_NAME}} {{.VBMC_CONTAINER_IMAGE}}
+      - docker run -d --privileged --rm --network kind -e SUSHY_EMULATOR_CONFIG=/etc/sushy/sushy-emulator.conf -v /var/run/libvirt:/var/run/libvirt -v "${PWD}/scripts/sushy.key:/etc/sushy/sushy.key" -v "${PWD}/scripts/sushy.cert:/etc/sushy/sushy.cert" -v "${PWD}/scripts/sushy-tools.conf:/etc/sushy/sushy-emulator.conf" -v "${PWD}/scripts/htpasswd:/etc/sushy/htpasswd" --name {{.VBMC_CONTAINER_NAME}} {{.VBMC_CONTAINER_IMAGE}}
     status:
       - docker ps | grep -q {{.VBMC_CONTAINER_NAME}}
 

--- a/capt/templates/bmc-machine.tmpl
+++ b/capt/templates/bmc-machine.tmpl
@@ -12,5 +12,10 @@ spec:
         insecureTLS: true
         port: $BMC_PORT
         providerOptions:
+            preferredOrder:
+                - ipmitool
             ipmitool:
                 port: $BMC_PORT
+            redfish:
+                useBasicAuth: true
+                systemName: $NODE_NAME

--- a/capt/templates/clusterctl.tmpl
+++ b/capt/templates/clusterctl.tmpl
@@ -1,7 +1,7 @@
 providers:
   - name: "tinkerbell"
-    url: "https://github.com/tinkerbell/cluster-api-provider-tinkerbell/releases/v$CAPT_VERSION/infrastructure-components.yaml"
+    url: "$LOCATION/$CAPT_VERSION/infrastructure-components.yaml"
     type: "InfrastructureProvider"
 images:
   infrastructure-tinkerbell:
-    tag: v$CAPT_VERSION
+    tag: $CAPT_VERSION

--- a/capt/templates/hardware.tmpl
+++ b/capt/templates/hardware.tmpl
@@ -22,6 +22,7 @@ spec:
                 netmask: 255.255.0.0
             lease_time: 4294967294
             mac: $NODE_MAC
+            uefi: true
             name_servers:
                 - 8.8.8.8
                 - 1.1.1.1

--- a/capt/templates/kustomization.tmpl
+++ b/capt/templates/kustomization.tmpl
@@ -13,6 +13,8 @@ patches:
       - op: add
         path: /spec/template/spec
         value:
+          bootOptions:
+            bootMode: netboot
           hardwareAffinity:
             required:
             - labelSelector:
@@ -30,15 +32,15 @@ patches:
                   - /dev/console:/dev/console
                   - /lib/firmware:/lib/firmware:ro
                 actions:
-                  - name: "stream-image"
-                    image: quay.io/tinkerbell-actions/oci2disk:v1.0.0
-                    timeout: 600
+                  - name: "stream image"
+                    image: quay.io/tinkerbell/actions/oci2disk
+                    timeout: 1200
                     environment:
                       IMG_URL: $OS_REGISTRY/$OS_DISTRO-$OS_VERSION:$KUBE_VERSION.gz
                       DEST_DISK: {{ index .Hardware.Disks 0 }}
                       COMPRESSED: true
-                  - name: "add-tink-cloud-init-config"
-                    image: quay.io/tinkerbell-actions/writefile:v1.0.0
+                  - name: "add tink cloud-init config"
+                    image: quay.io/tinkerbell/actions/writefile
                     timeout: 90
                     environment:
                       DEST_DISK: {{ formatPartition ( index .Hardware.Disks 0 ) 1 }}
@@ -62,8 +64,8 @@ patches:
                         manage_etc_hosts: localhost
                         warnings:
                           dsid_missing_source: off
-                  - name: "add-tink-cloud-init-ds-config"
-                    image: quay.io/tinkerbell-actions/writefile:v1.0.0
+                  - name: "add tink cloud-init ds-config"
+                    image: quay.io/tinkerbell/actions/writefile
                     timeout: 90
                     environment:
                       DEST_DISK: {{ formatPartition ( index .Hardware.Disks 0 ) 1 }}
@@ -75,15 +77,15 @@ patches:
                       DIRMODE: 0700
                       CONTENTS: |
                         datasource: Ec2
-                  - name: "kexec-image"
-                    image: ghcr.io/jacobweinstock/waitdaemon:0.2.0
+                  - name: "kexec image"
+                    image: ghcr.io/jacobweinstock/waitdaemon:0.2.1
                     timeout: 90
                     pid: host
                     environment:
                       BLOCK_DEVICE: {{ formatPartition ( index .Hardware.Disks 0 ) 1 }}
                       FS_TYPE: ext4
-                      IMAGE: quay.io/tinkerbell-actions/kexec:v1.0.0
-                      WAIT_SECONDS: 10
+                      IMAGE: quay.io/tinkerbell/actions/kexec
+                      WAIT_SECONDS: 5
                     volumes:
                       - /var/run/docker.sock:/var/run/docker.sock
   - target:
@@ -95,6 +97,8 @@ patches:
       - op: add
         path: /spec/template/spec
         value:
+          bootOptions:
+            bootMode: netboot
           hardwareAffinity:
             required:
             - labelSelector:
@@ -112,15 +116,15 @@ patches:
                   - /dev/console:/dev/console
                   - /lib/firmware:/lib/firmware:ro
                 actions:
-                  - name: "stream-image"
-                    image: quay.io/tinkerbell-actions/oci2disk:v1.0.0
-                    timeout: 600
+                  - name: "stream image"
+                    image: quay.io/tinkerbell/actions/oci2disk
+                    timeout: 1200
                     environment:
                       IMG_URL: $OS_REGISTRY/$OS_DISTRO-$OS_VERSION:$KUBE_VERSION.gz
                       DEST_DISK: {{ index .Hardware.Disks 0 }}
                       COMPRESSED: true
-                  - name: "add-tink-cloud-init-config"
-                    image: quay.io/tinkerbell-actions/writefile:v1.0.0
+                  - name: "add tink cloud-init config"
+                    image: quay.io/tinkerbell/actions/writefile
                     timeout: 90
                     environment:
                       DEST_DISK: {{ formatPartition ( index .Hardware.Disks 0 ) 1 }}
@@ -144,8 +148,8 @@ patches:
                         manage_etc_hosts: localhost
                         warnings:
                           dsid_missing_source: off
-                  - name: "add-tink-cloud-init-ds-config"
-                    image: quay.io/tinkerbell-actions/writefile:v1.0.0
+                  - name: "add tink cloud-init ds-config"
+                    image: quay.io/tinkerbell/actions/writefile
                     timeout: 90
                     environment:
                       DEST_DISK: {{ formatPartition ( index .Hardware.Disks 0 ) 1 }}
@@ -157,15 +161,15 @@ patches:
                       DIRMODE: 0700
                       CONTENTS: |
                         datasource: Ec2
-                  - name: "kexec-image"
-                    image: ghcr.io/jacobweinstock/waitdaemon:0.2.0
+                  - name: "kexec image"
+                    image: ghcr.io/jacobweinstock/waitdaemon:0.2.1
                     timeout: 90
                     pid: host
                     environment:
                       BLOCK_DEVICE: {{ formatPartition ( index .Hardware.Disks 0 ) 1 }}
                       FS_TYPE: ext4
-                      IMAGE: quay.io/tinkerbell-actions/kexec:v1.0.0
-                      WAIT_SECONDS: 10
+                      IMAGE: quay.io/tinkerbell/actions/kexec
+                      WAIT_SECONDS: 5
                     volumes:
                       - /var/run/docker.sock:/var/run/docker.sock
   - target:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Lots of updates/improvements. This adds the ability to specify local file locations for CAPT provider repo and a local directory for installing the helm chart. This also adds a redfish to libvirt emulator so that ISO mounting can be used.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
