### PR TITLE
Improve handling of super-admin.conf for kube-vip:

### DIFF
--- a/capt/tasks/Taskfile-capi.yaml
+++ b/capt/tasks/Taskfile-capi.yaml
@@ -121,8 +121,6 @@ tasks:
         sh: yq eval '.versions.kubevip' {{.STATE_FILE_FQ_PATH}}
       CONTROL_PLANE_VIP:
         sh: yq eval '.cluster.controlPlane.vip' {{.STATE_FILE_FQ_PATH}}
-      CONF_PATH: # https://github.com/kube-vip/kube-vip/issues/684
-        sh: "[[ $(echo {{.KUBE_VERSION}} | awk -F. '{print $2}') -gt 28 ]] && echo /etc/kubernetes/super-admin.conf || echo /etc/kubernetes/admin.conf"
     vars:
       KUBE_VERSION:
         sh: yq eval '.versions.kube' {{.STATE_FILE_FQ_PATH}}
@@ -138,6 +136,7 @@ tasks:
       - "{{.OUTPUT_DIR}}/kustomization.yaml"
     cmds:
       - envsubst "$(printf '${%s} ' $(env | cut -d'=' -f1))" < templates/{{.KUSTOMIZE_FILE}} > {{.OUTPUT_DIR}}/kustomization.yaml
+      # FYI, the `preKubeadmCommands` checks for k8s v1.29 because of https://github.com/kube-vip/kube-vip/issues/684
 
   apply-kustomization:
     run: once

--- a/capt/templates/kustomization-iso.tmpl
+++ b/capt/templates/kustomization-iso.tmpl
@@ -297,4 +297,4 @@ patches:
       - op: add
         path: /spec/kubeadmConfigSpec/preKubeadmCommands
         value:
-          - mkdir -p /etc/kubernetes/manifests && ctr images pull ghcr.io/kube-vip/kube-vip:v$KUBEVIP_VERSION && ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:v$KUBEVIP_VERSION vip /kube-vip manifest pod --arp --interface $(ip -4 -j route list default | jq -r .[0].dev) --address $CONTROL_PLANE_VIP --controlplane --leaderElection --k8sConfigPath $CONF_PATH > /etc/kubernetes/manifests/kube-vip.yaml
+          - if [ $(cat /etc/kubernetes-version | awk -F. '{print $2}') -eq 29 ]; then export KUBE_FILE=/etc/kubernetes/super-admin.conf; else export KUBE_FILE=/etc/kubernetes/admin.conf; fi && mkdir -p /etc/kubernetes/manifests && ctr images pull ghcr.io/kube-vip/kube-vip:v$KUBEVIP_VERSION && ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:v$KUBEVIP_VERSION vip /kube-vip manifest pod --arp --interface $(ip -4 -j route list default | jq -r .[0].dev) --address $CONTROL_PLANE_VIP --controlplane --leaderElection --k8sConfigPath $KUBE_FILE > /etc/kubernetes/manifests/kube-vip.yaml

--- a/capt/templates/kustomization-netboot.tmpl
+++ b/capt/templates/kustomization-netboot.tmpl
@@ -219,4 +219,4 @@ patches:
       - op: add
         path: /spec/kubeadmConfigSpec/preKubeadmCommands
         value:
-          - mkdir -p /etc/kubernetes/manifests && ctr images pull ghcr.io/kube-vip/kube-vip:v$KUBEVIP_VERSION && ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:v$KUBEVIP_VERSION vip /kube-vip manifest pod --arp --interface $(ip -4 -j route list default | jq -r .[0].dev) --address $CONTROL_PLANE_VIP --controlplane --leaderElection --k8sConfigPath $CONF_PATH > /etc/kubernetes/manifests/kube-vip.yaml
+          - if [ $(cat /etc/kubernetes-version | awk -F. '{print $2}') -eq 29 ]; then export KUBE_FILE=/etc/kubernetes/super-admin.conf; else export KUBE_FILE=/etc/kubernetes/admin.conf; fi && mkdir -p /etc/kubernetes/manifests && ctr images pull ghcr.io/kube-vip/kube-vip:v$KUBEVIP_VERSION && ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:v$KUBEVIP_VERSION vip /kube-vip manifest pod --arp --interface $(ip -4 -j route list default | jq -r .[0].dev) --address $CONTROL_PLANE_VIP --controlplane --leaderElection --k8sConfigPath $KUBE_FILE > /etc/kubernetes/manifests/kube-vip.yaml


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
K8s 1.29 has a kubeconfig file named different than other versions. https://github.com/kube-vip/kube-vip/issues/684
So we check for that version and use the other file (`super-admin.conf`).

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
